### PR TITLE
HOPSWORKS-562 

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -10,7 +10,6 @@ cookbook 'kkafka', github: "hopshadoop/kafka-cookbook", branch: "master"
 
 cookbook 'conda', github: "hopshadoop/conda-chef", branch: "master"
 cookbook 'hops', github: "hopshadoop/hops-hadoop-chef", branch: "master"
-cookbook 'hadoop_spark', github: "hopshadoop/spark-chef", branch: "master"
 
 cookbook 'elasticsearch', '~> 2.4.0'
 

--- a/Karamelfile
+++ b/Karamelfile
@@ -6,4 +6,3 @@ dependencies:
     global:  
       - elastic::default
       - hops::dn
-      - spark::yarn

--- a/Karamelfile
+++ b/Karamelfile
@@ -6,3 +6,4 @@ dependencies:
     global:  
       - elastic::default
       - hops::dn
+      - spark::yarn

--- a/metadata.rb
+++ b/metadata.rb
@@ -16,7 +16,6 @@ depends 'kagent'
 depends 'elastic'
 depends 'kkafka'
 depends 'hops'
-depends 'hadoop_spark'
 
 recipe "hopslog::install", "Installs Logstash and Kibana Server"
 recipe "hopslog::default", "configures Logstash and Kibana Server"

--- a/recipes/_logstash.rb
+++ b/recipes/_logstash.rb
@@ -3,31 +3,6 @@ my_private_ip = my_private_ip()
 
 elastic = private_recipe_ip("elastic", "default") + ":#{node['elastic']['port']}"
 
-
-# Add spark log4j.properties file to HDFS. Used by Logstash.
-
-template "#{Chef::Config['file_cache_path']}/log4j.properties" do
-  source "app.log4j.properties.erb"
-  owner node['hopslog']['user']
-  group node['hopslog']['group']
-  mode 0755
-  action :create
-  variables({
-              :private_ip => my_private_ip
-            })
-end
-
-logs_dir="/user/#{node['hadoop_spark']['user']}"
-
-hops_hdfs_directory "#{Chef::Config['file_cache_path']}/log4j.properties" do
-  action :put_as_superuser
-  owner node['hadoop_spark']['user']
-  group node['hops']['group']
-  mode "1775"
-  dest "#{logs_dir}/log4j.properties"
-end
-
-
 template"#{node['logstash']['base_dir']}/conf/spark-streaming.conf" do
   source "spark-streaming.conf.erb"
   owner node['hopslog']['user']

--- a/recipes/_logstash.rb
+++ b/recipes/_logstash.rb
@@ -9,7 +9,7 @@ elastic = private_recipe_ip("elastic", "default") + ":#{node['elastic']['port']}
 template "#{Chef::Config['file_cache_path']}/log4j.properties" do
   source "app.log4j.properties.erb"
   owner node['hopslog']['user']
-  owner node['hopslog']['group']
+  group node['hopslog']['group']
   mode 0755
   action :create
   variables({

--- a/recipes/_logstash.rb
+++ b/recipes/_logstash.rb
@@ -9,7 +9,8 @@ elastic = private_recipe_ip("elastic", "default") + ":#{node['elastic']['port']}
 template "#{Chef::Config['file_cache_path']}/log4j.properties" do
   source "app.log4j.properties.erb"
   owner node['hopslog']['user']
-  mode 0750
+  owner node['hopslog']['group']
+  mode 0755
   action :create
   variables({
               :private_ip => my_private_ip


### PR DESCRIPTION
https://github.com/hopshadoop/hopslog-chef/blob/master/recipes/_logstash.rb#L9

The log4j.properties is instantiated from the template with owner elastic:root (hopslog_user:root) and 750 permission. It is then copied into hops using the hdfs user, which cannot read this file.

Under certain inter-leavings it seems someone elsecopies this file there. If this recipe is the first one to perform the copy it will fail.

Fix - change ownership to hopslog_user:hopslog_group and permission 755. As a log config it is ok to be readable by all.